### PR TITLE
Fix build dir

### DIFF
--- a/.github/actions/build_and_push/action.yml
+++ b/.github/actions/build_and_push/action.yml
@@ -53,8 +53,7 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
         IMAGE_TAG: ${{ inputs.docker_tag }}
       run: |
-        cd ${{ inputs.build_dir }}
-        docker build -t $ECR_REPOSITORY:$IMAGE_TAG -f ${{ inputs.dockerfile_name }} .
+        docker build -t $ECR_REPOSITORY:$IMAGE_TAG -f ${{ inputs.dockerfile_name }} ${{ inputs.build_dir }}
 
     - name: Tag and push image to Amazon ECR
       shell: bash

--- a/.github/actions/deploy_to_aws/action.yml
+++ b/.github/actions/deploy_to_aws/action.yml
@@ -1,0 +1,50 @@
+name: Deploy to AWS
+inputs:
+  docker_tag:
+    description: "Commit short SHA"
+    required: true
+    type: string
+  stack_name:
+    required: true
+    type: string
+  aws_region:
+    required: true
+    type: string
+  pulumi_command:
+    type: string
+    default: up
+  pulumi_diff:
+    default: "false"
+  PULUMI_ACCESS_TOKEN:
+    required: true
+  AWS_ACCESS_KEY_ID:
+    required: true
+  AWS_SECRET_ACCESS_KEY:
+    required: true
+  OP_SERVICE_ACCOUNT_TOKEN:
+    required: true
+runs:
+  using: composite
+  steps:
+    - run: |
+        pulumi stack select -c ${{ inputs.stack_name }}
+        pulumi config -s ${{ inputs.stack_name }} set aws:region ${{ inputs.aws_region }} --non-interactive
+      shell: bash
+      working-directory: infra/aws
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ inputs.PULUMI_ACCESS_TOKEN }}
+    - uses: pulumi/actions@v5
+      id: pulumi
+      with:
+        command: ${{ inputs.pulumi_command }}
+        diff: ${{ inputs.pulumi_diff }}
+        stack-name: ${{ inputs.stack_name }}
+        upsert: false
+        work-dir: infra/aws
+      env:
+        PULUMI_ACCESS_TOKEN: ${{ inputs.PULUMI_ACCESS_TOKEN }}
+        AWS_ACCESS_KEY_ID: ${{ inputs.AWS_ACCESS_KEY_ID }}
+        AWS_SECRET_ACCESS_KEY: ${{ inputs.AWS_SECRET_ACCESS_KEY }}
+        AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
+        DOCKER_IMAGE_TAG: ${{ inputs.docker_tag }}
+        OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/actions/deploy_to_aws/action.yml
+++ b/.github/actions/deploy_to_aws/action.yml
@@ -23,6 +23,9 @@ inputs:
     required: true
   OP_SERVICE_ACCOUNT_TOKEN:
     required: true
+  CLOUDFLARE_API_TOKEN:
+    required: false
+    default: ""
 runs:
   using: composite
   steps:
@@ -48,3 +51,4 @@ runs:
         AWS_DEFAULT_REGION: ${{ inputs.aws_region }}
         DOCKER_IMAGE_TAG: ${{ inputs.docker_tag }}
         OP_SERVICE_ACCOUNT_TOKEN: ${{ inputs.OP_SERVICE_ACCOUNT_TOKEN }}
+        CLOUDFLARE_API_TOKEN: ${{ inputs.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION

- adding actions to deploy to AWS
- fix build of docker image, build dir is now passed as argument to the docker command instead of doing a `cd` into it