### PR TITLE
fix: disable provenance to prevent OCI Image Index in ECR

### DIFF
--- a/.github/actions/build_and_push/action.yml
+++ b/.github/actions/build_and_push/action.yml
@@ -57,7 +57,7 @@ runs:
         ECR_REPOSITORY: ${{ inputs.ecr_repository_name }}
         IMAGE_TAG: ${{ inputs.docker_tag }}
       run: |
-        docker build -t $ECR_REPOSITORY:$IMAGE_TAG -f ${{ inputs.dockerfile_name }} ${{ inputs.build_dir }}
+        docker build --provenance=false -t $ECR_REPOSITORY:$IMAGE_TAG -f ${{ inputs.dockerfile_name }} ${{ inputs.build_dir }}
 
     - name: Tag and push image to Amazon ECR
       shell: bash


### PR DESCRIPTION
Newer GitHub Actions runners alias `docker build` to `docker buildx build`, which enables provenance attestations by default. This causes pushes to create Image Index (manifest list) artifacts instead of plain images, breaking Lambda deployments that expect tags to point directly to an image.